### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flowbuild/diagrams",
-  "version": "1.5.0-rc.10",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@flowbuild/diagrams",
-      "version": "1.5.0-rc.10",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@flowbuild/diagrams-core": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowbuild/diagrams",
-  "version": "1.5.0-rc.10",
+  "version": "1.5.0",
   "description": "Service to handle diagrams manager",
   "main": "src/server.js",
   "scripts": {


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.5.0](https://github.com/flow-build/diagrams/releases/tag/v1.5.0)